### PR TITLE
Conserta erro em requisição de atividade por parlamentar

### DIFF
--- a/server/routes/tweets.js
+++ b/server/routes/tweets.js
@@ -91,40 +91,7 @@ router.get("/parlamentares/:id_parlamentar", (req, res) => {
       }
     )
       .then((tweets) => {
-        const max = Math.max.apply(
-          Math,
-          tweets.map((tweet) => tweet.dataValues.atividade_twitter)
-        );
-        const min = Math.min.apply(
-          Math,
-          tweets.map((tweet) => tweet.dataValues.atividade_twitter)
-        );
-        Tweet.findOne({
-          group: ["id_parlamentar_parlametria"],
-          attributes: [
-            "id_parlamentar_parlametria",
-            [
-              Sequelize.fn(
-                "COUNT",
-                Sequelize.col("id_parlamentar_parlametria")
-              ),
-              "atividade_twitter",
-            ],
-          ],
-          where: {
-            id_parlamentar_parlametria: id_parlamentar,
-          },
-        })
-          .then((tweet) => {
-            res.status(status.SUCCESS).json({
-              id_parlamentar_parlametria:
-                tweet.dataValues.id_parlamentar_parlametria,
-              atividade_twitter: +tweet.dataValues.atividade_twitter,
-              max_atividade_twitter: max,
-              min_atividade_twitter: min,
-            });
-          })
-          .catch((err) => res.status(status.BAD_REQUEST).json({ err }));
+        res.status(status.SUCCESS).json(AgregaTweetsPorTemaEParlamentar(tweets, id_parlamentar, false));
       })
       .catch((err) => res.status(status.BAD_REQUEST).json({ err }));
   } else {
@@ -161,7 +128,7 @@ router.get("/parlamentares/:id_parlamentar", (req, res) => {
       .then((tweets) => {
         res
           .status(status.SUCCESS)
-          .json(AgregaTweetsPorTemaEParlamentar(tweets, id_parlamentar));
+          .json(AgregaTweetsPorTemaEParlamentar(tweets, id_parlamentar, true));
       })
       .catch((err) => res.status(status.BAD_REQUEST).json({ err }));
   }

--- a/server/utils/functions.js
+++ b/server/utils/functions.js
@@ -80,7 +80,7 @@ function AgregaTweetsPorTema(resultado) {
   return data;
 }
 
-function AgregaTweetsPorTemaEParlamentar(tweets, id_parlamentar) {
+function AgregaTweetsPorTemaEParlamentar(tweets, id_parlamentar, agregaTema) {
   let data = {
     id_parlamentar_parlametria: id_parlamentar,
     atividade_twitter: 0,
@@ -88,26 +88,23 @@ function AgregaTweetsPorTemaEParlamentar(tweets, id_parlamentar) {
     min_atividade_twitter: 0,
   };
 
+  const tweetsProcessados = tweets.map((tweet) => tweet.get({ plain: true }));
+
   if (tweets.length > 0) {
-    const tweetsPorTema = AgregaTweetsPorTema(tweets);
+    if (agregaTema === true) {
+      tweetsProcessados = AgregaTweetsPorTema(tweets);
+    }
 
     const max_atividade_twitter = Math.max.apply(
       Math,
-      tweetsPorTema.map(function (o) {
-        return o.atividade_twitter;
-      })
-    );
-    const min_atividade_twitter = Math.min.apply(
-      Math,
-      tweetsPorTema.map(function (o) {
+      tweetsProcessados.map(function (o) {
         return o.atividade_twitter;
       })
     );
 
     data.max_atividade_twitter = max_atividade_twitter;
-    data.min_atividade_twitter = min_atividade_twitter;
 
-    const atividade_twitter = tweetsPorTema.filter((el) => {
+    const atividade_twitter = tweetsProcessados.filter((el) => {
       return el.id_parlamentar_parlametria == id_parlamentar;
     });
 

--- a/server/utils/functions.js
+++ b/server/utils/functions.js
@@ -81,6 +81,7 @@ function AgregaTweetsPorTema(resultado) {
 }
 
 function AgregaTweetsPorTemaEParlamentar(tweets, id_parlamentar, agregaTema) {
+
   let data = {
     id_parlamentar_parlametria: id_parlamentar,
     atividade_twitter: 0,
@@ -88,7 +89,7 @@ function AgregaTweetsPorTemaEParlamentar(tweets, id_parlamentar, agregaTema) {
     min_atividade_twitter: 0,
   };
 
-  const tweetsProcessados = tweets.map((tweet) => tweet.get({ plain: true }));
+  let tweetsProcessados = tweets.map((tweet) => tweet.get({ plain: true }));
 
   if (tweets.length > 0) {
     if (agregaTema === true) {


### PR DESCRIPTION

**Mudanças neste PR:**

- Adiciona retorno de objeto default para um parlamentar sem tweets sobre as proposições que monitoramos

> ex: Para a requisição [http://localhost:5001/api/tweets/parlamentares/1160642?tema=]( http://localhost:5001/api/tweets/parlamentares/1160642?tema=), o retorno será:
{
  "id_parlamentar_parlametria": "1160642",
  "atividade_twitter": 0,
  "max_atividade_twitter": 82,
  "min_atividade_twitter": 0
}