### PR TITLE
Retorna percentual de tweets para todos os parlamentares por semana

### DIFF
--- a/server/utils/queries/percentual_tweets_queries.js
+++ b/server/utils/queries/percentual_tweets_queries.js
@@ -1,42 +1,63 @@
 
-function QueryPercentualAtividadeAgregadaPorAgenda(interesse, dataInicial, dataFinal, idParlamentar) {
+function QueryPercentualAtividadeAgregadaPorAgenda(interesse, dataInicial, dataFinal) {
   const q = "SELECT " +
-  "res.tema_slug AS tema_slug, res.atividade_twitter AS atividade_twitter, " +
-  "SUM(res.atividade_twitter) OVER (PARTITION BY res.slug) AS total FROM (" +
+  "res.tema_slug AS tema_slug, " +
+  "res.atividade_twitter AS atividade_twitter,  " +
+  "res.id_parlamentar_parlametria, " +
+  "res.week, res.year, " +
+  "SUM(res.atividade_twitter) OVER (PARTITION BY res.slug, res.week, res.year, res.id_parlamentar_parlametria) AS total FROM (" +
   "SELECT " +
   "agenda.slug, tema.slug AS tema_slug, " +
-  "COUNT(tweet.id_tweet) AS atividade_twitter " +
+  "COUNT(tweet.id_tweet) AS atividade_twitter, " +
+  "tweet.id_parlamentar_parlametria AS id_parlamentar_parlametria, " +
+  "date_part('week', created_at) as week, " +
+  "date_part('year', created_at) as year " +
   "FROM tema_proposicao "+
   "INNER JOIN proposicao ON tema_proposicao.id_proposicao_leggo = proposicao.id_proposicao_leggo " +
   "INNER JOIN agenda_proposicao ON agenda_proposicao.id_proposicao_leggo = proposicao.id_proposicao_leggo " +
   "INNER JOIN agenda ON agenda_proposicao.id_agenda = agenda.id AND agenda.slug = '" + interesse + "' " +
   "INNER JOIN tweet_proposicao ON proposicao.id_proposicao_leggo = tweet_proposicao.id_proposicao_leggo " +
   "INNER JOIN tweet ON tweet_proposicao.id_tweet = tweet.id_tweet AND tweet.created_at BETWEEN '"+
-  dataInicial +"' AND '"+ dataFinal + "' AND tweet.id_parlamentar_parlametria = '" + idParlamentar + "' " +
+  dataInicial +"' AND '"+ dataFinal + "' " +
   "INNER JOIN tema ON tema_proposicao.id_tema = tema.id " +
-  "GROUP BY tema.slug, agenda.slug) AS res;";
+  "GROUP BY tema.slug, agenda.slug, tweet.id_parlamentar_parlametria, week, year) AS res;";
 
   return q;
 }
 
-function QueryPercentualAtividadeAgregadaPorAgendaETema(interesse, tema, dataInicial, dataFinal, idParlamentar) {
-  const q = "SELECT tt.tema_slug, tt.atividade_twitter, tt.total " +
+function QueryPercentualAtividadeAgregadaPorAgendaETema(interesse, tema, dataInicial, dataFinal) {
+  const q = "SELECT " +
+  "tt.tema_slug, " +
+  "tt.atividade_twitter, " +
+  "tt.total, " +
+  "tt.id_parlamentar_parlametria, " +
+  "tt.week, " +
+  "tt.year " +
   "FROM (" +
   "SELECT " +
-  "res.tema_slug AS tema_slug, res.atividade_twitter AS atividade_twitter, " +
-  "SUM(res.atividade_twitter) OVER (PARTITION BY res.slug) AS total FROM (" +
+  "res.tema_slug AS tema_slug, " +
+  "res.atividade_twitter AS atividade_twitter, " +
+  "res.id_parlamentar_parlametria AS id_parlamentar_parlametria, " +
+  "res.week AS week, " +
+  "res.year AS year, " +
+  "SUM(res.atividade_twitter) OVER (" +
+  "PARTITION BY res.slug, res.week, res.year, res.id_parlamentar_parlametria) AS total " +
+  "FROM (" +
   "SELECT " +
   "agenda.slug, tema.slug AS tema_slug, " +
-  "COUNT(tweet.id_tweet) AS atividade_twitter " +
+  "tweet.id_parlamentar_parlametria AS id_parlamentar_parlametria, " +
+  "COUNT(tweet.id_tweet) AS atividade_twitter, " +
+  "date_part('week', created_at) as week, " +
+  "date_part('year', created_at) as year " +
   "FROM tema_proposicao "+
   "INNER JOIN proposicao ON tema_proposicao.id_proposicao_leggo = proposicao.id_proposicao_leggo " +
   "INNER JOIN agenda_proposicao ON agenda_proposicao.id_proposicao_leggo = proposicao.id_proposicao_leggo " +
   "INNER JOIN agenda ON agenda_proposicao.id_agenda = agenda.id AND agenda.slug = '" + interesse + "' " +
   "INNER JOIN tweet_proposicao ON proposicao.id_proposicao_leggo = tweet_proposicao.id_proposicao_leggo " +
   "INNER JOIN tweet ON tweet_proposicao.id_tweet = tweet.id_tweet AND tweet.created_at BETWEEN '"+
-  dataInicial +"' AND '"+ dataFinal + "' AND tweet.id_parlamentar_parlametria = '" + idParlamentar + "' " +
+  dataInicial +"' AND '"+ dataFinal + "' " +
   "INNER JOIN tema ON tema_proposicao.id_tema = tema.id " +
-  "GROUP BY tema.slug, agenda.slug) AS res) AS tt " +
+  "GROUP BY tema.slug, agenda.slug, tweet.id_parlamentar_parlametria, week, year) AS res) AS tt " +
   "where tt.tema_slug = '" + tema + "';";
 
   return q;

--- a/server/utils/queries/percentual_tweets_queries.js
+++ b/server/utils/queries/percentual_tweets_queries.js
@@ -28,25 +28,19 @@ function QueryPercentualAtividadeAgregadaPorAgendaETema(interesse, tema, dataIni
   "tt.tema_slug, " +
   "tt.atividade_twitter, " +
   "tt.total, " +
-  "tt.id_parlamentar_parlametria, " +
-  "tt.week, " +
-  "tt.year " +
+  "tt.id_parlamentar_parlametria " +
   "FROM (" +
   "SELECT " +
   "res.tema_slug AS tema_slug, " +
   "res.atividade_twitter AS atividade_twitter, " +
   "res.id_parlamentar_parlametria AS id_parlamentar_parlametria, " +
-  "res.week AS week, " +
-  "res.year AS year, " +
   "SUM(res.atividade_twitter) OVER (" +
-  "PARTITION BY res.slug, res.week, res.year, res.id_parlamentar_parlametria) AS total " +
+  "PARTITION BY res.slug, res.id_parlamentar_parlametria) AS total " +
   "FROM (" +
   "SELECT " +
   "agenda.slug, tema.slug AS tema_slug, " +
   "tweet.id_parlamentar_parlametria AS id_parlamentar_parlametria, " +
-  "COUNT(tweet.id_tweet) AS atividade_twitter, " +
-  "date_part('week', created_at) as week, " +
-  "date_part('year', created_at) as year " +
+  "COUNT(tweet.id_tweet) AS atividade_twitter " +
   "FROM tema_proposicao "+
   "INNER JOIN proposicao ON tema_proposicao.id_proposicao_leggo = proposicao.id_proposicao_leggo " +
   "INNER JOIN agenda_proposicao ON agenda_proposicao.id_proposicao_leggo = proposicao.id_proposicao_leggo " +
@@ -55,7 +49,7 @@ function QueryPercentualAtividadeAgregadaPorAgendaETema(interesse, tema, dataIni
   "INNER JOIN tweet ON tweet_proposicao.id_tweet = tweet.id_tweet AND tweet.created_at BETWEEN '"+
   dataInicial +"' AND '"+ dataFinal + "' " +
   "INNER JOIN tema ON tema_proposicao.id_tema = tema.id " +
-  "GROUP BY tema.slug, agenda.slug, tweet.id_parlamentar_parlametria, week, year) AS res) AS tt " +
+  "GROUP BY tema.slug, agenda.slug, tweet.id_parlamentar_parlametria) AS res) AS tt " +
   "where tt.tema_slug = '" + tema + "';";
 
   return q;

--- a/server/utils/queries/percentual_tweets_queries.js
+++ b/server/utils/queries/percentual_tweets_queries.js
@@ -1,13 +1,12 @@
 
 function QueryPercentualAtividadeAgregadaPorAgenda(interesse, dataInicial, dataFinal) {
   const q = "SELECT " +
-  "res.tema_slug AS tema_slug, " +
   "res.atividade_twitter AS atividade_twitter,  " +
   "res.id_parlamentar_parlametria, " +
   "res.week, res.year, " +
-  "SUM(res.atividade_twitter) OVER (PARTITION BY res.slug, res.week, res.year, res.id_parlamentar_parlametria) AS total FROM (" +
+  "SUM(res.atividade_twitter) OVER (PARTITION BY res.week, res.year, res.id_parlamentar_parlametria) AS total FROM (" +
   "SELECT " +
-  "agenda.slug, tema.slug AS tema_slug, " +
+  "agenda.slug, " +
   "COUNT(tweet.id_tweet) AS atividade_twitter, " +
   "tweet.id_parlamentar_parlametria AS id_parlamentar_parlametria, " +
   "date_part('week', created_at) as week, " +
@@ -20,7 +19,7 @@ function QueryPercentualAtividadeAgregadaPorAgenda(interesse, dataInicial, dataF
   "INNER JOIN tweet ON tweet_proposicao.id_tweet = tweet.id_tweet AND tweet.created_at BETWEEN '"+
   dataInicial +"' AND '"+ dataFinal + "' " +
   "INNER JOIN tema ON tema_proposicao.id_tema = tema.id " +
-  "GROUP BY tema.slug, agenda.slug, tweet.id_parlamentar_parlametria, week, year) AS res;";
+  "GROUP BY agenda.slug, tweet.id_parlamentar_parlametria, week, year) AS res ORDER BY total DESC;";
 
   return q;
 }

--- a/server/utils/queries/percentual_tweets_queries.js
+++ b/server/utils/queries/percentual_tweets_queries.js
@@ -2,24 +2,23 @@
 function QueryPercentualAtividadeAgregadaPorAgenda(interesse, dataInicial, dataFinal) {
   const q = "SELECT " +
   "res.atividade_twitter AS atividade_twitter,  " +
+  "res.slug, " +
   "res.id_parlamentar_parlametria, " +
-  "res.week, res.year, " +
-  "SUM(res.atividade_twitter) OVER (PARTITION BY res.week, res.year, res.id_parlamentar_parlametria) AS total FROM (" +
+  "SUM(res.atividade_twitter) OVER (PARTITION BY res.slug, res.id_parlamentar_parlametria) AS total FROM (" +
   "SELECT " +
-  "agenda.slug, " +
+  "agenda.slug AS slug, " +
   "COUNT(tweet.id_tweet) AS atividade_twitter, " +
-  "tweet.id_parlamentar_parlametria AS id_parlamentar_parlametria, " +
-  "date_part('week', created_at) as week, " +
-  "date_part('year', created_at) as year " +
+  "tweet.id_parlamentar_parlametria AS id_parlamentar_parlametria " +
   "FROM tema_proposicao "+
   "INNER JOIN proposicao ON tema_proposicao.id_proposicao_leggo = proposicao.id_proposicao_leggo " +
   "INNER JOIN agenda_proposicao ON agenda_proposicao.id_proposicao_leggo = proposicao.id_proposicao_leggo " +
-  "INNER JOIN agenda ON agenda_proposicao.id_agenda = agenda.id AND agenda.slug = '" + interesse + "' " +
+  "INNER JOIN agenda ON agenda_proposicao.id_agenda = agenda.id " +
   "INNER JOIN tweet_proposicao ON proposicao.id_proposicao_leggo = tweet_proposicao.id_proposicao_leggo " +
   "INNER JOIN tweet ON tweet_proposicao.id_tweet = tweet.id_tweet AND tweet.created_at BETWEEN '"+
   dataInicial +"' AND '"+ dataFinal + "' " +
   "INNER JOIN tema ON tema_proposicao.id_tema = tema.id " +
-  "GROUP BY agenda.slug, tweet.id_parlamentar_parlametria, week, year) AS res ORDER BY total DESC;";
+  "GROUP BY agenda.slug, tweet.id_parlamentar_parlametria) AS res " +
+  "WHERE res.slug = '" + interesse + "' ORDER BY total DESC;";
 
   return q;
 }


### PR DESCRIPTION
**Mudanças neste PR:**

- Agrupa dados de percentual por semana;
- Retorna percentual para todos os parlamentares;
- Modifica ordem de declaração de rotas.

Exemplo de chamada: http://localhost:5001/api/parlamentares/percentual_atividade_agenda?data_inicial=01-01-2000&data_final=10-10-2020