### PR TITLE
Adiciona endpoint para recuperar tweets de um parlamentar ordenados por engajamento

### DIFF
--- a/server/routes/tweets.js
+++ b/server/routes/tweets.js
@@ -11,7 +11,8 @@ const calculaMaxAtividade = require("../utils/functions");
 
 const {
   QueryAtividadeAgregadaPorAgenda,
-  QueryAtividadeAgregadaPorTemaEAgenda
+  QueryAtividadeAgregadaPorTemaEAgenda,
+  QueryTweetsPorTemaEAgenda
 } = require("../utils/queries/tweets_queries");
 
 const Tweet = models.tweet;
@@ -81,6 +82,43 @@ router.get("/parlamentares/:id_parlamentar", (req, res) => {
       res
         .status(status.SUCCESS)
         .json(calculaMaxAtividade(tweets, id_parlamentar, false));
+    })
+    .catch((err) => res.status(status.BAD_REQUEST).json({ err: err.message }));
+});
+
+// Tweets de um parlamentar ordenados por engajamento
+// Formato das datas: ano-mes-dia
+// Se tema for undefined então todos os temas serão considerados
+// Se limit for setado então apenas os n primeiros tweets serão retornados
+router.get("/:id_parlamentar/texto", (req, res) => {
+  const idParlamentar = req.params.id_parlamentar;
+  const tema = req.query.tema;
+  const interesse = req.query.interesse;
+  const limit = req.query.limit;
+
+  let dataInicial = req.query.data_inicial;
+  let dataFinal = req.query.data_final;
+
+  dataInicial = moment(dataInicial).format("YYYY-MM-DD");
+  dataFinal = moment(dataFinal).format("YYYY-MM-DD");
+
+  let query;
+
+  query = QueryTweetsPorTemaEAgenda(
+    idParlamentar,
+    tema,
+    interesse,
+    dataInicial,
+    dataFinal,
+    limit
+  );
+
+  models.sequelize
+    .query(query, {
+      type: Sequelize.QueryTypes.SELECT,
+    })
+    .then((tweets) => {
+      res.status(status.SUCCESS).json(tweets);
     })
     .catch((err) => res.status(status.BAD_REQUEST).json({ err: err.message }));
 });

--- a/server/utils/queries/tweets_queries.js
+++ b/server/utils/queries/tweets_queries.js
@@ -36,5 +36,28 @@ function QueryAtividadeAgregadaPorTemaEAgenda(tema, interesse, dataInicial, data
   return q;
 }
 
+// Se tema for undefined então todos os temas serão considerados
+function QueryTweetsPorTemaEAgenda(idParlamentar, tema, interesse, dataInicial, dataFinal, limit) {
+  const q = "SELECT " +
+  "DISTINCT(tweet.id_tweet), " +
+  "tweet.id_parlamentar_parlametria, tweet.created_at, tweet.text, tweet.interactions, " +
+  "tweet.url " +
+  "FROM tema_proposicao "+
+  "INNER JOIN proposicao ON tema_proposicao.id_proposicao_leggo = proposicao.id_proposicao_leggo " +
+  "INNER JOIN agenda_proposicao ON agenda_proposicao.id_proposicao_leggo = proposicao.id_proposicao_leggo " +
+  "INNER JOIN agenda ON agenda_proposicao.id_agenda = agenda.id AND agenda.slug = '" + interesse + "' " +
+  "INNER JOIN tweet_proposicao ON proposicao.id_proposicao_leggo = tweet_proposicao.id_proposicao_leggo " +
+  "INNER JOIN tweet ON tweet_proposicao.id_tweet = tweet.id_tweet AND tweet.created_at BETWEEN '"+
+  dataInicial +"' AND '"+ dataFinal + "' " +
+  "AND tweet_proposicao.relator_proposicao = FALSE " +
+  "AND tweet.id_parlamentar_parlametria = '" + idParlamentar + "' " +
+  "INNER JOIN tema ON tema_proposicao.id_tema = tema.id " +
+  (tema !== undefined ? "AND tema.slug = '" + tema + "' ": "") +
+  "ORDER BY tweet.interactions DESC" +
+  (limit !== undefined ? " LIMIT " + limit + " ": "")
+  return q;
+}
+
 module.exports = { QueryAtividadeAgregadaPorAgenda,
-                    QueryAtividadeAgregadaPorTemaEAgenda }
+                    QueryAtividadeAgregadaPorTemaEAgenda,
+                    QueryTweetsPorTemaEAgenda }


### PR DESCRIPTION
## Mudanças
- Adiciona endpoint para recuperar tweets de um parlamentar ordenados por engajamento

## Flags
Endpoints para testes
- http://localhost:5001/api/tweets/2825/texto?interesse=congresso-remoto&data_inicial=2020-01-01&data_final=2020-07-01
- http://localhost:5001/api/tweets/2825/texto?interesse=congresso-remoto&data_inicial=2020-01-01&data_final=2020-07-01&limit=5&tema=outros