### PR TITLE
Passa a considerar todos os tweets independente de agenda e tema para os endpoints de engajamento e média

### DIFF
--- a/server/routes/parlamentares.js
+++ b/server/routes/parlamentares.js
@@ -14,28 +14,22 @@ const {
 } = require("../utils/queries/percentual_tweets_queries");
 
 const {
-  QueryEngajamentoAgregadoPorAgenda,
-  QueryEngajamentoAgregadoPorAgendaETema
+  QueryEngajamentoAgregado
 } = require("../utils/queries/engajamento_queries");
 
 const Tweet = models.tweet;
 
 const {
-  QueryAtividadeAgregadaPorAgenda,
-  QueryAtividadeAgregadaPorTemaEAgenda
+  QueryAtividadeAgregada
 } = require("../utils/queries/tweets_queries");
 
+// Formato da data YYYY-MM-DD
 router.get("/media", (req, res) => {
+  const dataInicial = req.query.data_inicial;
+  const dataFinal = req.query.data_final;
 
-  const tema = req.query.tema;
-  const interesse = "congresso-remoto"; //req.query.interesse;
-
-  // mes - dia - ano
-  let dataInicial = req.query.data_inicial;
-  let dataFinal = req.query.data_final;
-
-  var dataInicialFormat = new Date(dataInicial);
-  var dataFinalFormat = new Date(dataFinal);
+  dataFinalFormat = moment(dataInicial).format("YYYY-MM-DD");
+  dataInicialFormat = moment(dataFinal).format("YYYY-MM-DD");
 
   let diferenca_meses = Math.trunc(
     Math.abs(
@@ -47,21 +41,7 @@ router.get("/media", (req, res) => {
     diferenca_meses = 1;
   }
 
-  let query;
-  if (typeof tema === "undefined" || tema === "") {
-    query = QueryAtividadeAgregadaPorAgenda(
-      interesse,
-      dataInicial,
-      dataFinal
-    );
-  } else {
-    query = QueryAtividadeAgregadaPorTemaEAgenda(
-      tema,
-      interesse,
-      dataInicial,
-      dataFinal
-    );
-  }
+  const query = QueryAtividadeAgregada(dataInicial, dataFinal);
 
   models.sequelize
     .query(query, {
@@ -125,33 +105,15 @@ router.get("/percentual_atividade_agenda", (req, res) => {
     .catch((err) => res.status(status.BAD_REQUEST).json({ err }));
 });
 
+// Formato da data YYYY-MM-DD
 router.get("/engajamento", (req, res) => {
-  const agenda = "congresso-remoto"; // req.query.interesse;
-  const tema = req.query.tema;
-
   let dataInicial = req.query.data_inicial;
   let dataFinal = req.query.data_final;
 
   dataInicial = moment(dataInicial).format("YYYY-MM-DD");
   dataFinal = moment(dataFinal).format("YYYY-MM-DD");
 
-  let query;
-  if (typeof tema === "undefined" || tema === "") {
-    query = QueryEngajamentoAgregadoPorAgenda(
-      agenda,
-      dataInicial,
-      dataFinal
-    );
-  } else {
-    query = QueryEngajamentoAgregadoPorAgendaETema(
-      agenda,
-      tema,
-      dataInicial,
-      dataFinal
-    );
-  }
-
-  console.log(query)
+  const query = QueryEngajamentoAgregado(dataInicial, dataFinal)
 
   models.sequelize
     .query(query, {

--- a/server/utils/queries/engajamento_queries.js
+++ b/server/utils/queries/engajamento_queries.js
@@ -35,6 +35,19 @@ function QueryEngajamentoAgregadoPorAgendaETema(interesse, tema, dataInicial, da
   return q;
 }
 
+function QueryEngajamentoAgregado(dataInicial, dataFinal) {
+  const q = "SELECT " +
+  "tweet.id_parlamentar_parlametria AS id_parlamentar_parlametria, " +
+  "AVG(tweet.interactions) AS engajamento " +
+  "FROM tweet "+
+  "WHERE tweet.created_at BETWEEN '"+
+  dataInicial +"' AND '"+ dataFinal + "' " +
+  "GROUP BY tweet.id_parlamentar_parlametria;";
+
+  return q;
+}
+
 module.exports = {
   QueryEngajamentoAgregadoPorAgenda,
-  QueryEngajamentoAgregadoPorAgendaETema }
+  QueryEngajamentoAgregadoPorAgendaETema,
+  QueryEngajamentoAgregado }

--- a/server/utils/queries/tweets_queries.js
+++ b/server/utils/queries/tweets_queries.js
@@ -68,7 +68,20 @@ function QueryTweetsInfo() {
   return q;
 }
 
+function QueryAtividadeAgregada(dataInicial, dataFinal) {
+  const q = "SELECT " +
+  "tweet.id_parlamentar_parlametria, " +
+  "COUNT(DISTINCT(tweet.id_tweet)) AS atividade_twitter " +
+  "FROM tweet "+
+  "WHERE tweet.created_at BETWEEN '"+
+  dataInicial +"' AND '"+ dataFinal + "' " +
+  "GROUP BY tweet.id_parlamentar_parlametria;";
+
+  return q;
+}
+
 module.exports = { QueryAtividadeAgregadaPorAgenda,
                     QueryAtividadeAgregadaPorTemaEAgenda,
+                    QueryAtividadeAgregada,
                     QueryTweetsPorTemaEAgenda,
                     QueryTweetsInfo }


### PR DESCRIPTION
## Mudanças
- Passa a considerar todos os tweets independente de agenda e tema para os endpoints de engajamento e média

## Flags
- Antes de merjar é necessário confirmar se é realmente correto ignorar a agenda e o tema para os cálculos do engajamento e média.
