### PR TITLE
Retorna objeto vazio quando o username de um parlamentar não tiver sido encontrado

### DIFF
--- a/server/routes/parlamentares.js
+++ b/server/routes/parlamentares.js
@@ -178,10 +178,13 @@ router.get("/username/:id_parlamentar", (req, res) => {
   })
     .then((tweets) => {
 
-      const data = {
-        "username": tweets[0].username,
-        "total_tweets": tweets.length
-      };
+      let data = {};
+      if (tweets.length > 0) {
+        data = {
+          "username": tweets[0].username,
+          "total_tweets": tweets.length
+        };
+      }
 
       res.status(status.SUCCESS).json(data);
     })


### PR DESCRIPTION
## Mudanças
- Retorna objeto vazio quando o username de um parlamentar não tiver sido encontrado

## Flags
- Deve ser revisado em conjunto com o PR https://github.com/parlametria/leggo-painel/pull/150