### PR TITLE
Adiciona filtro de destaque aos endpoints 

### DIFF
--- a/server/routes/proposicoes.js
+++ b/server/routes/proposicoes.js
@@ -18,6 +18,7 @@ router.get("/parlamentar/:id", (req, res) => {
   let dataInicial = req.query.data_inicial;
   let dataFinal = req.query.data_final;
   let qtd = req.query.qtd;
+  const destaque = req.query.destaque;
 
   dataInicial = moment(dataInicial).format("YYYY-MM-DD");
   dataFinal = moment(dataFinal).format("YYYY-MM-DD");
@@ -32,13 +33,14 @@ router.get("/parlamentar/:id", (req, res) => {
   }
 
   let query;
-  if (typeof tema === "undefined" || tema === "") {
+  if (typeof tema === "undefined" || tema === "" || destaque === "true") {
     query = QueryProposicoesComMaisTweetsPorParlamentar(
       interesse,
       dataInicial,
       dataFinal,
       id_parlamentar,
-      qtd
+      qtd,
+      destaque
     );
   } else {
     query = QueryProposicoesComMaisTweetsPorTemaEParlamentar(

--- a/server/routes/tweets.js
+++ b/server/routes/tweets.js
@@ -119,6 +119,7 @@ router.get("/:id_parlamentar/texto", (req, res) => {
   const tema = req.query.tema;
   const interesse = req.query.interesse;
   const limit = req.query.limit;
+  const destaque = req.query.destaque;
 
   let dataInicial = req.query.data_inicial;
   let dataFinal = req.query.data_final;
@@ -134,7 +135,8 @@ router.get("/:id_parlamentar/texto", (req, res) => {
     interesse,
     dataInicial,
     dataFinal,
-    limit
+    limit,
+    destaque
   );
 
   models.sequelize

--- a/server/routes/tweets.js
+++ b/server/routes/tweets.js
@@ -13,7 +13,8 @@ const {
   QueryAtividadeAgregadaPorAgenda,
   QueryAtividadeAgregadaPorTemaEAgenda,
   QueryTweetsPorTemaEAgenda,
-  QueryTweetsInfo
+  QueryTweetsInfo,
+  QueryAtividadeAgregadaPorAgendaEDestaque
 } = require("../utils/queries/tweets_queries");
 
 const Tweet = models.tweet;
@@ -21,6 +22,7 @@ const Tweet = models.tweet;
 router.get("/parlamentares", (req, res) => {
   const tema = req.query.tema;
   const interesse = req.query.interesse;
+  const destaque = req.query.destaque;
 
   let dataInicial = req.query.data_inicial;
   let dataFinal = req.query.data_final;
@@ -29,7 +31,14 @@ router.get("/parlamentares", (req, res) => {
   dataFinal = moment(dataFinal).format("YYYY-MM-DD");
 
   let query;
-  if (typeof tema === "undefined" || tema === "") {
+
+  if (destaque === "true") {
+    query = QueryAtividadeAgregadaPorAgendaEDestaque(
+      interesse,
+      dataInicial,
+      dataFinal
+    );
+  } else if (typeof tema === "undefined" || tema === "") {
     query = QueryAtividadeAgregadaPorAgenda(
       interesse,
       dataInicial,
@@ -58,6 +67,7 @@ router.get("/parlamentares/:id_parlamentar", (req, res) => {
   const id_parlamentar = req.params.id_parlamentar;
   const tema = req.query.tema;
   const interesse = req.query.interesse;
+  const destaque = req.query.destaque;
 
   let dataInicial = req.query.data_inicial;
   let dataFinal = req.query.data_final;
@@ -66,7 +76,14 @@ router.get("/parlamentares/:id_parlamentar", (req, res) => {
   dataFinal = moment(dataFinal).format("YYYY-MM-DD");
 
   let query;
-  if (typeof tema === "undefined" || tema === "") {
+
+  if (destaque === "true") {
+    query = QueryAtividadeAgregadaPorAgendaEDestaque(
+      interesse,
+      dataInicial,
+      dataFinal
+    );
+  } else if (typeof tema === "undefined" || tema === "") {
     query = QueryAtividadeAgregadaPorAgenda(
       interesse,
       dataInicial,

--- a/server/utils/queries/proposicoes_queries.js
+++ b/server/utils/queries/proposicoes_queries.js
@@ -1,4 +1,4 @@
-function QueryProposicoesComMaisTweetsPorParlamentar(interesse, dataInicial, dataFinal, id_parlamentar, qtd) {
+function QueryProposicoesComMaisTweetsPorParlamentar(interesse, dataInicial, dataFinal, id_parlamentar, qtd, destaque) {
   const q ="SELECT " +
     "tweet_proposicao.id_proposicao_leggo, proposicao.sigla, COUNT(tweet_proposicao.id_tweet) AS num_tweets " +
     "FROM " +
@@ -7,6 +7,7 @@ function QueryProposicoesComMaisTweetsPorParlamentar(interesse, dataInicial, dat
     "AND tweet.id_parlamentar_parlametria = '" + id_parlamentar + "' " +
     "AND tweet.created_at BETWEEN '" + dataInicial + "' AND '" + dataFinal + "' " +
     "INNER JOIN proposicao ON tweet_proposicao.id_proposicao_leggo = proposicao.id_proposicao_leggo " +
+    (destaque === 'true' ? "AND proposicao.destaque = TRUE " : "") +
     "INNER JOIN agenda_proposicao ON agenda_proposicao.id_proposicao_leggo = tweet_proposicao.id_proposicao_leggo " +
     "INNER JOIN agenda ON agenda_proposicao.id_agenda = agenda.id AND agenda.slug = '" + interesse + "' " +
     "GROUP BY tweet_proposicao.id_proposicao_leggo,  proposicao.sigla " +

--- a/server/utils/queries/tweets_queries.js
+++ b/server/utils/queries/tweets_queries.js
@@ -37,7 +37,7 @@ function QueryAtividadeAgregadaPorTemaEAgenda(tema, interesse, dataInicial, data
 }
 
 // Se tema for undefined então todos os temas serão considerados
-function QueryTweetsPorTemaEAgenda(idParlamentar, tema, interesse, dataInicial, dataFinal, limit) {
+function QueryTweetsPorTemaEAgenda(idParlamentar, tema, interesse, dataInicial, dataFinal, limit, destaque) {
   const q = "SELECT " +
   "DISTINCT(tweet.id_tweet), " +
   "tweet.id_parlamentar_parlametria, tweet.created_at, tweet.text, tweet.interactions, " +
@@ -53,6 +53,7 @@ function QueryTweetsPorTemaEAgenda(idParlamentar, tema, interesse, dataInicial, 
   "AND tweet.id_parlamentar_parlametria = '" + idParlamentar + "' " +
   "INNER JOIN tema ON tema_proposicao.id_tema = tema.id " +
   (tema !== undefined ? "AND tema.slug = '" + tema + "' ": "") +
+  (destaque === 'true' ? " AND proposicao.destaque = TRUE " : "") +
   "ORDER BY tweet.interactions DESC" +
   (limit !== undefined ? " LIMIT " + limit + " ": "");
 

--- a/server/utils/queries/tweets_queries.js
+++ b/server/utils/queries/tweets_queries.js
@@ -83,8 +83,30 @@ function QueryAtividadeAgregada(dataInicial, dataFinal) {
   return q;
 }
 
+function QueryAtividadeAgregadaPorAgendaEDestaque(interesse, dataInicial, dataFinal) {
+  const q = `SELECT
+    tweet.id_parlamentar_parlametria,
+    COUNT(tweet.id_tweet) AS atividade_twitter
+  FROM
+    tweet
+    INNER JOIN tweet_proposicao ON (tweet_proposicao.id_tweet = tweet.id_tweet)
+    INNER JOIN proposicao ON (proposicao.id_proposicao_leggo = tweet_proposicao.id_proposicao_leggo)
+    INNER JOIN agenda_proposicao ON (agenda_proposicao.id_proposicao_leggo = proposicao.id_proposicao_leggo)
+    INNER JOIN agenda ON (agenda_proposicao.id_agenda = agenda.id)
+  WHERE
+    agenda.slug = '${interesse}' AND
+    tweet.created_at BETWEEN '${dataInicial}' AND '${dataFinal}' AND
+    tweet_proposicao.relator_proposicao = FALSE AND
+    proposicao.destaque = TRUE
+  GROUP BY
+    tweet.id_parlamentar_parlametria;`;
+
+  return q;
+}
+
 module.exports = { QueryAtividadeAgregadaPorAgenda,
                     QueryAtividadeAgregadaPorTemaEAgenda,
                     QueryAtividadeAgregada,
                     QueryTweetsPorTemaEAgenda,
-                    QueryTweetsInfo }
+                    QueryTweetsInfo,
+                    QueryAtividadeAgregadaPorAgendaEDestaque }


### PR DESCRIPTION
**Mudanças neste PR**

- Adiciona nova query para retornar atividade no twitter considerando o destaque e modifica os existentes;
- Modifica endpoints existentes para adicionar filtro de destaque.

**OBS:** O banco do leggo-twitter-dados deve estar na versão da branch [2315-props-destaque](https://github.com/parlametria/leggo-twitter-dados/tree/2315-props-destaque).